### PR TITLE
fix equality for network in constants

### DIFF
--- a/packages/react-app/src/constants.js
+++ b/packages/react-app/src/constants.js
@@ -18,7 +18,7 @@ export const DAI_ABI = [{"inputs":[{"internalType":"uint256","name":"chainId_","
 
 export const NETWORK = (chainId)=>{
   for(let n in NETWORKS){
-    if(NETWORKS[n].chainId==chainId){
+    if(NETWORKS[n].chainId===chainId){
       return NETWORKS[n]
     }
   }


### PR DESCRIPTION
In the constants file the chainId makes an equality with two equal signs rather than three:
```NETWORKS[n].chainId==chainId```

Added the third equals sign.